### PR TITLE
add drawing lib, improve simple V

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,14 @@ distro:
 update-v: 3rdparty/v
 	cd 3rdparty/v && ( git checkout $(V_COMMIT) || ( git checkout master && git pull && git checkout $(V_COMMIT) && $(MAKE) ) )
 
+<<<<<<< HEAD
 .PHONY: kernel/vos.elf
 kernel/vos.elf: update-v
 	$(MAKE) -C kernel V="`realpath ./3rdparty/v/v`" CC="`realpath ./build/tools/host-gcc/bin/x86_64-vos-gcc`"
+=======
+kernel/vos.elf: 3rdparty/v $(ALL_V_FILES)
+	$(MAKE) -C kernel V="`realpath ./3rdparty/v/v`"
+>>>>>>> 0c9ae24... sync Makefile, move dbg to x86
 
 $(KERNEL_HDD): 3rdparty/limine 3rdparty/echfs kernel/vos.elf
 	rm -f $(KERNEL_HDD)

--- a/kernel/main.v
+++ b/kernel/main.v
@@ -1,7 +1,22 @@
+module main
+
 import lib
 import memory
 import stivale2
 import x86
+import drawing
+
+const (
+	boxcolor   = 0xff77ff
+	vcolor     = 0x536b8a // from V logo
+	vthickness = 10
+	vwidth     = 500
+	vy         = 100
+	vx         = 100
+)
+
+fn C._vcleanup()
+fn C._vinit(___argc int, ___argv voidptr)
 
 pub fn kmain(stivale2_struct &stivale2.Struct) {
 	memmap_tag := unsafe { &stivale2.MemmapTag(stivale2.get_tag(stivale2_struct, stivale2.memmap_id)) }
@@ -22,12 +37,34 @@ pub fn kmain(stivale2_struct &stivale2.Struct) {
 	// Initialize the earliest arch structures.
 	x86.gdt_init()
 	x86.idt_init()
+	// C._vinit(0, 0) // makes array initializations and other unsupported stuff
 
 	// Test pmm
 	mut ptr := memory.malloc(40)
 	ptr = memory.realloc(ptr, 8000)
 	memory.free(ptr)
+	// Fetch required tags.
+	fb_tag := unsafe { &stivale2.FBTag(stivale2.get_tag(stivale2_struct, stivale2.framebuffer_id)) }
+	memmap_tag := unsafe { &stivale2.MemmapTag(stivale2.get_tag(stivale2_struct, stivale2.memmap_id)) }
+	if fb_tag == 0 || memmap_tag == 0 {
+		lib.panic_kernel('Could not fetch all the required tags')
+	}
 
+	// Initialize the memory allocator.
+	memory.physical_init(memmap_tag)
+	mut fb := drawing.new_fb(fb_tag)
+
+	fb.rect(800, 100, 100, 100, boxcolor)
+
+	// big V
+	for x in 0 .. vwidth / 2 {
+		for i in 0 .. vthickness + 1 {
+			fb.set(x + vx + i, x * 2 + vy, vcolor)
+			fb.set(x + vx + i, x * 2 + vy - 1, vcolor)
+			fb.set(500 - x + vx + i, x * 2 + vy, vcolor)
+			fb.set(500 - x + vx + i, x * 2 + vy - 1, vcolor)
+		}
+	}
 	for {
 		asm volatile amd64 {
 			hlt

--- a/kernel/modules/drawing/drawing.v
+++ b/kernel/modules/drawing/drawing.v
@@ -37,9 +37,20 @@ pub fn (mut fb FB) set(x int, y int, color u32) {
 // rect draws a rectangle on fb. 
 // `x` and `y` are the position of the upper-left corner of the rectangle relative to the upper-left corner of the screen
 pub fn (mut fb FB) rect(x int, y int, width int, height int, color u32) {
+	// if width > 8 {
+	// asm i386 {
+	// 	vpbroadcastd ymm1, color
+	// 	; ; r (color)
+	// 	; ymm1
+	// }
+	// } else {
 	for i := x; i < x + width; i++ {
 		for j := y; j < y + height; j++ {
 			fb.set(i, j, color)
 		}
 	}
+	// }
+}
+
+pub fn (mut fb FB) line(x1 int, y1 int, x2 int, y2 int, color u32) {
 }

--- a/kernel/modules/drawing/drawing.v
+++ b/kernel/modules/drawing/drawing.v
@@ -1,0 +1,45 @@
+module drawing
+
+import stivale2
+
+pub fn new_fb(tag stivale2.FBTag) FB {
+	return FB{
+		addr: &u32(tag.addr)
+		height: int(tag.height)
+		width: int(tag.width)
+		pitch: int(tag.pitch)
+	}
+}
+
+pub struct FB {
+mut:
+	addr  &u32
+	pitch int
+pub:
+	height int // int because most people use int
+	width  int
+}
+
+pub fn (mut fb FB) set(x int, y int, color u32) {
+	if x > fb.width || x < 0 {
+		// 'x out of bounds'
+		for {}
+	}
+	if y > fb.height || y < 0 {
+		// 'y out of bounds'
+		for {}
+	}
+	unsafe {
+		fb.addr[(fb.pitch / 4) * y + x] = color
+	}
+}
+
+// rect draws a rectangle on fb. 
+// `x` and `y` are the position of the upper-left corner of the rectangle relative to the upper-left corner of the screen
+pub fn (mut fb FB) rect(x int, y int, width int, height int, color u32) {
+	for i := x; i < x + width; i++ {
+		for j := y; j < y + height; j++ {
+			fb.set(i, j, color)
+		}
+	}
+}

--- a/kernel/modules/x86/io.v
+++ b/kernel/modules/x86/io.v
@@ -19,3 +19,18 @@ pub fn outb(port u16, value byte) {
 		; memory
 	}
 }
+
+// dbg writes `s` to the qemu debug port
+pub fn dbg(s string) {
+	for i := 0; i < s.len; i++ {
+		outb(0xe9, s[i]) // 0xe9 is qemu's debug port
+	}
+}
+
+// dbg writes `s` to the qemu debug port, with a newline
+pub fn dbgln(s string) {
+	for i := 0; i < s.len; i++ {
+		outb(0xe9, s[i]) // 0xe9 is qemu's debug port
+	}
+	outb(0xe9, `\n`)
+}


### PR DESCRIPTION
This improves the simple V @spytheman made by increasing the thickness and making it the blue V color.
In addition, there is a simple drawing lib that can be used to set the color at `x, y` coordinates (with bounds checking), and also draw rectangles.
One thing I noticed was that the build flags had `-O3` which greatly slowed down compilation, and the runtime happened pretty much instantly anyway with `-O0` (This project is still very small).

TODO:
 - [ ] Optimization for `rect`
 - [ ] Lines
 - [x] Circles